### PR TITLE
Run in GUI mode with menu bar icon

### DIFF
--- a/assets/launchd/com.github.ljagiello.airdash.plist
+++ b/assets/launchd/com.github.ljagiello.airdash.plist
@@ -8,7 +8,6 @@
 	<key>ProgramArguments</key>
 	<array>
 		<string>{{BINARY_PATH}}</string>
-		<string>--daemon</string>
 		<string>--config</string>
 		<string>{{CONFIG_PATH}}</string>
 	</array>


### PR DESCRIPTION
## Summary

Fixes missing menu bar icon - app was running in headless daemon mode.

## Issue

The LaunchAgent was configured with the `--daemon` flag, which runs the app in headless mode without any UI. Users couldn't see the menu bar icon with air quality data.

## Fix

Remove `--daemon` flag from LaunchAgent plist so the app runs in GUI mode and displays the menu bar icon.

## Changes

- Remove `--daemon` argument from ProgramArguments in LaunchAgent plist
- App will now run in GUI mode with visible menu bar icon

## Testing

After this change:
1. Uninstall existing daemon: `/Applications/AirDash.app/Contents/MacOS/airdash uninstall`
2. Install with new version: `/Applications/AirDash.app/Contents/MacOS/airdash install`
3. Menu bar icon should appear with air quality data